### PR TITLE
migrate embedding and re-ranker to modal

### DIFF
--- a/python/config.py
+++ b/python/config.py
@@ -3,18 +3,14 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-MXBAI_API_URL = (
-    "https://api-inference.huggingface.co/models/mixedbread-ai/mxbai-embed-large-v1"
-)
-EMBEDDING_DIM = 1024  # Dimension of embeddings from https://huggingface.co/mixedbread-ai/mxbai-embed-large-v1/blob/main/config.json#L11
-MXBAI_RERANK_URL = (
-    "https://api-inference.huggingface.co/models/mixedbread-ai/mxbai-rerank-xsmall-v1"
-)
-HF_API_KEY = os.getenv("HUGGINGFACE_TOKEN")
-MXBAI_HEADERS = {"Authorization": f"Bearer {HF_API_KEY}"}
+EMBEDDING_DIM = 1024
+INFINITY_BASE_URL = "https://muhtasham--infinity-serve.modal.run"
+INFINITY_API_KEY = "sk-dummy"
+
 QDRANT_PATH = "embeddings/vector_db"
-COLLECTION_NAME = "diffusion_studio_docs"  # More specific name
+COLLECTION_NAME = "diffusion_studio_docs"
 ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
+PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH = os.getenv("PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH")
 
 MAX_RETRIES = 10
 RETRY_DELAY = 10  # seconds


### PR DESCRIPTION
Embedding (size 1024)

```python
import asyncio
from openai import AsyncOpenAI

client = AsyncOpenAI(
    api_key="sk-dummy", base_url="https://muhtasham--infinity-serve.modal.run"
)

async def main():
    response = await client.embeddings.create(
        model="mixedbread-ai/mxbai-embed-large-v1", input="What is Deep Learning?"
    )
    embeddings = response.data[0].embedding
    print(f"Embeddings: {embeddings}")


asyncio.run(main())
```

Re-Ranker
```
import requests

resp = requests.post("https://muhtasham--infinity-serve.modal.run/rerank",
    json={
        "model":"mixedbread-ai/mxbai-rerank-base-v1",
        "query":"Where is Munich?",
        "documents":["Munich is in Germany.", "The sky is blue."]
    })

print(resp.json())
````
Sync version above but you can also use httpx to call it async way